### PR TITLE
Fix libpq linking with as-needed on 9.x and 10/11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 EXTENSION = omnidb_plpgsql_debugger
 DATA = omnidb_plpgsql_debugger--1.0.0.sql
-MODULES = omnidb_plpgsql_debugger
+OBJS = omnidb_plpgsql_debugger.o
+MODULE_big = omnidb_plpgsql_debugger
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 override CPPFLAGS := $(CPPFLAGS) -I$(shell $(PG_CONFIG) --includedir)
-override LDFLAGS := $(LDFLAGS) -lpq
+SHLIB_LINK = -lpq
 include $(PGXS)


### PR DESCRIPTION
CREATE EXTENSION omnidb_plpgsql_debugger
ERROR:  could not load library "/usr/lib/postgresql/11/lib/omnidb_plpgsql_debugger.so": /usr/lib/postgresql/11/lib/omnidb_plpgsql_debugger.so: undefined symbol: PQstatus